### PR TITLE
Add external_id field to accounting transactions API.

### DIFF
--- a/_includes/1.0/api/json/transaction.json
+++ b/_includes/1.0/api/json/transaction.json
@@ -1,5 +1,6 @@
 {
   "id": 509878,
+  "external_id": "EXT-API-079",
   "transaction_code": 1639,
   "date": "2014-01-31",
   "journal_id": 7,

--- a/_includes/1.0/api/transaction.html
+++ b/_includes/1.0/api/transaction.html
@@ -18,6 +18,13 @@
                 <td>Automatically assigned when creating Transactions</td>
             </tr>
             <tr>
+                <td>external_id</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Use primilary for Sync.<br /></td>
+            </tr>
+            <tr>
                 <td>transaction_code</td>
                 <td>{{ site.format.type.integer }}</td>
                 <td>no</td>


### PR DESCRIPTION
Since you can import accounting transactions, an external reference could be handy.