### PR TITLE
docs: add credit memo installments and payments API documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,10 @@ resource:
     url: /credit_memo_payments
   vendor_credit_memos:
     url: /vendor_credit_memos
+  vendor_credit_memo_installments:
+    url: /vendor_credit_memo_installments
+  vendor_credit_memo_payments:
+    url: /vendor_credit_memo_payments
   items:
     url: /items
   payment_terms:

--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,10 @@ resource:
     url: /bill_payments
   credit_memos:
     url: /credit_memos
+  credit_memo_installments:
+    url: /credit_memo_installments
+  credit_memo_payments:
+    url: /credit_memo_payments
   vendor_credit_memos:
     url: /vendor_credit_memos
   items:

--- a/_includes/1.0/api/credit-memo-installment.html
+++ b/_includes/1.0/api/credit-memo-installment.html
@@ -1,0 +1,57 @@
+<div id="creditmemoinstallment" class="group">
+
+    <h2>Credit Memo Installments</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.credit_memo_installments.url}}{% endhighlight %}
+    <p class="message bg-primary">This API is read only.</p>
+    <h3 id="creditmemoinstallmentjsonformat">JSON Format</h3>
+    <p>Credit Memo Installments are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header-readonly.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>Automatically assigned.</td>
+            </tr>
+            <tr>
+                <td>credit_memo_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>Id of the related <a href="/docs/1.0/api/#creditmemo" title="">Credit Memo</a>.</td>
+            </tr>
+            <tr>
+                <td>due_date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>The expected payment date.<br/>Format: {{ site.format.date }}<br/></td>
+            </tr>
+            <tr>
+                <td>amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>The installment initial amount.</td>
+            </tr>
+            <tr>
+                <td>outstanding_amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>
+                    Amount left to settle.<br />
+                    An outstanding amount of 0.00 means that the Installment has been fully paid.
+                </td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>The ISO code of the currency
+                    <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="creditmemoinstallmentjsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/credit_memo_installment.json %}{% endhighlight %}
+
+    <h3 id="creditmemoinstallmentavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/readonly.html %}
+</div>

--- a/_includes/1.0/api/credit-memo-payment.html
+++ b/_includes/1.0/api/credit-memo-payment.html
@@ -1,0 +1,104 @@
+<div id="creditmemopayment" class="group">
+
+    <h2>Credit Memo Payments</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.credit_memo_payments.url}}{% endhighlight %}
+    <p>Credit Memo Payment creation is restrained to Credit Memo payments into the API. You have to provide a <i>credit_memo_id</i> while performing a POST request.
+        <br />That new payment will be applied on the first open installment of that credit memo. If all installments are paid, an error message will be returned and the payment won't be created.
+        <br />Also, that new payment currency will be determined by the credit memo's one.
+        <br /><i>bank_id</i> is mandatory when creating a credit memo payment.
+        <br />
+        <br />Unlike creation, GET requests are not restrained to credit memo payments only and return any kind of credit memo payments.</p>
+    <h3 id="creditmemopaymentjsonformat">JSON Format</h3>
+    <p>Credit Memo Payments are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Automatically assigned when creating a Credit Memo Payment.</td>
+            </tr>
+            <tr>
+                <td>user_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The number that was automatically assigned to this credit memo payment (i.e. CMPAY-002).</td>
+            </tr>
+            <tr>
+                <td>credit_memo_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>yes</td>
+                <td>yes</td>
+                <td>Id of the <a href="/docs/1.0/api/#creditmemo" title="">Credit Memo</a> that payment is about.</td>
+            </tr>
+            <tr>
+                <td>date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The date the payment has occurred.<br />Format: {{ site.format.date }}<br />Default: date of the day.</td>
+            </tr>
+            <tr>
+                <td>amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Amount of the payment.<br />Default: remaining unpaid amount of the first open installment.<br />Should not be 0.00.</td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The ISO code of that payment currency <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>.<br />Derived from the credit memo's currency.</td>
+            </tr>
+            <tr>
+                <td>payment_method_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Id of the Payment method.<br />Default: the one of the installment that payment has been applied.</td>
+            </tr>
+            <tr>
+                <td>bank_reference</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>A bank reference label that can freely be assigned. Could be a bank statement reference, a transfer ID, etc...</td>
+            </tr>
+            <tr>
+                <td>bank_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>yes</td>
+                <td>yes</td>
+                <td>Id of the bank account that payment was made from.<br />That bank account currency must match the credit memo's currency.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="creditmemopaymentjsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/credit_memo_payment.json %}{% endhighlight %}
+
+    <h3 id="creditmemopaymentfilter">Available Filter Fields</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        {% include table-header-filter.html %}
+        </thead>
+        <tbody>
+        <tr>
+            <td>credit_memo_id</td>
+            <td>Filter by credit memo ID. Only available for GET operation to retrieve the list of payments for a specific credit memo.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 id="creditmemopaymentavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/noput.html %}
+
+</div>

--- a/_includes/1.0/api/creditmemo.html
+++ b/_includes/1.0/api/creditmemo.html
@@ -207,6 +207,13 @@
                 <td>yes</td>
                 <td>The final total the customer needs to pay. All include (taxes, discounts, reduce).</td>
             </tr>
+            <tr>
+                <td>installments</td>
+                <td>array[<a href="/docs/1.0/api/#creditmemoinstallment" title="">Credit Memo Installment</a>]</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>An array of the installments (settlements) generated for that credit memo based on its payment terms.</td>
+            </tr>
         </tbody>
     </table>
 

--- a/_includes/1.0/api/json/credit_memo.json
+++ b/_includes/1.0/api/json/credit_memo.json
@@ -59,5 +59,15 @@
   "subtotal": 1000.0,
   "reduce_amount": 2.0,
   "tax_amount": 0.0,
-  "total": 998.0
+  "total": 998.0,
+  "installments": [
+    {
+      "id": 10004,
+      "credit_memo_id": 10001,
+      "due_date": "2020-08-08",
+      "amount": 998.0,
+      "outstanding_amount": 998.0,
+      "currency_iso_code": "USD"
+    }
+  ]
 }

--- a/_includes/1.0/api/json/credit_memo_installment.json
+++ b/_includes/1.0/api/json/credit_memo_installment.json
@@ -1,0 +1,8 @@
+{
+  "id": 10004,
+  "credit_memo_id": 10001,
+  "due_date": "2020-10-27",
+  "amount": 998.0,
+  "outstanding_amount": 998.0,
+  "currency_iso_code": "USD"
+}

--- a/_includes/1.0/api/json/credit_memo_payment.json
+++ b/_includes/1.0/api/json/credit_memo_payment.json
@@ -1,0 +1,11 @@
+{
+  "id": 28,
+  "user_code": "CMPAY-028",
+  "credit_memo_id": 10001,
+  "date": "2020-08-11",
+  "amount": 99.0,
+  "currency_iso_code": "USD",
+  "payment_method_id": 1,
+  "bank_reference": "BK-XCT-094843904 PAY",
+  "bank_id": 5
+}

--- a/_includes/1.0/api/json/vendor_credit_memo.json
+++ b/_includes/1.0/api/json/vendor_credit_memo.json
@@ -14,5 +14,15 @@
   "reduce_amount": 0.0,
   "tax_amount": 375.2,
   "total": 2251.2,
-  "attachments": []
+  "attachments": [],
+  "installments": [
+    {
+      "id": 10005,
+      "vendor_credit_memo_id": 10000,
+      "due_date": "2020-11-06",
+      "amount": 2251.2,
+      "outstanding_amount": 0.0,
+      "currency_iso_code": "GBP"
+    }
+  ]
 }

--- a/_includes/1.0/api/json/vendor_credit_memo_installment.json
+++ b/_includes/1.0/api/json/vendor_credit_memo_installment.json
@@ -1,0 +1,8 @@
+{
+  "id": 10005,
+  "vendor_credit_memo_id": 10000,
+  "due_date": "2020-11-06",
+  "amount": 2251.2,
+  "outstanding_amount": 0.0,
+  "currency_iso_code": "GBP"
+}

--- a/_includes/1.0/api/json/vendor_credit_memo_payment.json
+++ b/_includes/1.0/api/json/vendor_credit_memo_payment.json
@@ -1,0 +1,11 @@
+{
+  "id": 29,
+  "user_code": "SCNPAY-029",
+  "vendor_credit_memo_id": 10000,
+  "date": "2020-11-06",
+  "amount": 2251.2,
+  "currency_iso_code": "GBP",
+  "payment_method_id": 1,
+  "bank_reference": "BK-XCT-094843905 PAY",
+  "bank_id": 5
+}

--- a/_includes/1.0/api/vendor-credit-memo-installment.html
+++ b/_includes/1.0/api/vendor-credit-memo-installment.html
@@ -1,0 +1,57 @@
+<div id="vendorcreditmemoinstallment" class="group">
+
+    <h2>Vendor Credit Memo Installments</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.vendor_credit_memo_installments.url}}{% endhighlight %}
+    <p class="message bg-primary">This API is read only.</p>
+    <h3 id="vendorcreditmemoinstallmentjsonformat">JSON Format</h3>
+    <p>Vendor Credit Memo Installments are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header-readonly.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>Automatically assigned.</td>
+            </tr>
+            <tr>
+                <td>vendor_credit_memo_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>Id of the related <a href="/docs/1.0/api/#vendorcreditmemo" title="">Vendor Credit Memo</a>.</td>
+            </tr>
+            <tr>
+                <td>due_date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>The expected payment date.<br/>Format: {{ site.format.date }}<br/></td>
+            </tr>
+            <tr>
+                <td>amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>The installment initial amount.</td>
+            </tr>
+            <tr>
+                <td>outstanding_amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>
+                    Amount left to settle.<br />
+                    An outstanding amount of 0.00 means that the Installment has been fully paid.
+                </td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>The ISO code of the currency
+                    <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="vendorcreditmemoinstallmentjsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/vendor_credit_memo_installment.json %}{% endhighlight %}
+
+    <h3 id="vendorcreditmemoinstallmentavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/readonly.html %}
+</div>

--- a/_includes/1.0/api/vendor-credit-memo-payment.html
+++ b/_includes/1.0/api/vendor-credit-memo-payment.html
@@ -1,0 +1,104 @@
+<div id="vendorcreditmemopayment" class="group">
+
+    <h2>Vendor Credit Memo Payments</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.vendor_credit_memo_payments.url}}{% endhighlight %}
+    <p>Vendor Credit Memo Payment creation is restrained to Vendor Credit Memo payments into the API. You have to provide a <i>vendor_credit_memo_id</i> while performing a POST request.
+        <br />That new payment will be applied on the first open installment of that vendor credit memo. If all installments are paid, an error message will be returned and the payment won't be created.
+        <br />Also, that new payment currency will be determined by the vendor credit memo's one.
+        <br /><i>bank_id</i> is mandatory when creating a vendor credit memo payment.
+        <br />
+        <br />Unlike creation, GET requests are not restrained to vendor credit memo payments only and return any kind of vendor credit memo payments.</p>
+    <h3 id="vendorcreditmemopaymentjsonformat">JSON Format</h3>
+    <p>Vendor Credit Memo Payments are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Automatically assigned when creating a Vendor Credit Memo Payment.</td>
+            </tr>
+            <tr>
+                <td>user_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The number that was automatically assigned to this vendor credit memo payment (i.e. SCNPAY-002).</td>
+            </tr>
+            <tr>
+                <td>vendor_credit_memo_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>yes</td>
+                <td>yes</td>
+                <td>Id of the <a href="/docs/1.0/api/#vendorcreditmemo" title="">Vendor Credit Memo</a> that payment is about.</td>
+            </tr>
+            <tr>
+                <td>date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The date the payment has occurred.<br />Format: {{ site.format.date }}<br />Default: date of the day.</td>
+            </tr>
+            <tr>
+                <td>amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Amount of the payment.<br />Default: remaining unpaid amount of the first open installment.<br />Should not be 0.00.</td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The ISO code of that payment currency <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>.<br />Derived from the vendor credit memo's currency.</td>
+            </tr>
+            <tr>
+                <td>payment_method_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Id of the Payment method.<br />Default: the one of the installment that payment has been applied.</td>
+            </tr>
+            <tr>
+                <td>bank_reference</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>A bank reference label that can freely be assigned. Could be a bank statement reference, a transfer ID, etc...</td>
+            </tr>
+            <tr>
+                <td>bank_id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>yes</td>
+                <td>yes</td>
+                <td>Id of the bank account that payment was made from.<br />That bank account currency must match the vendor credit memo's currency.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="vendorcreditmemopaymentjsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/vendor_credit_memo_payment.json %}{% endhighlight %}
+
+    <h3 id="vendorcreditmemopaymentfilter">Available Filter Fields</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        {% include table-header-filter.html %}
+        </thead>
+        <tbody>
+        <tr>
+            <td>vendor_credit_memo_id</td>
+            <td>Filter by vendor credit memo ID. Only available for GET operation to retrieve the list of payments for a specific vendor credit memo.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 id="vendorcreditmemopaymentavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/noput.html %}
+
+</div>

--- a/_includes/1.0/api/vendor-credit-memo.html
+++ b/_includes/1.0/api/vendor-credit-memo.html
@@ -119,12 +119,19 @@
                 <td>yes</td>
                 <td>The final total due by the vendor. All include (taxes, discounts, reduce).</td>
             </tr>
+            <tr>
+                <td>installments</td>
+                <td>array[<a href="/docs/1.0/api/#vendorcreditmemoinstallment" title="">Vendor Credit Memo Installment</a>]</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>An array of the installments (settlements) generated for that vendor credit memo based on its payment terms.</td>
+            </tr>
 
         </tbody>
     </table>
 
     <h3 id="vendorcreditmemojsonexample">JSON Example</h3>
-    {% highlight bash %}{% include 1.0/api/json/vendor_bill.json %}{% endhighlight %}
+    {% highlight bash %}{% include 1.0/api/json/vendor_credit_memo.json %}{% endhighlight %}
 
     <h3 id="vendorcreditmemosorting">Available Sorting Options</h3>
     <table class="table table-bordered table-striped">

--- a/docs/1.0/api/index.html
+++ b/docs/1.0/api/index.html
@@ -257,6 +257,32 @@ title: "- REST API V1.0 Resources"
               <li><a href="#creditmemoprint">Print as PDF</a></li>
           </ul>
       </li>
+      <!-- credit memo installments -->
+      <li>
+          <a href="#creditmemoinstallment">Credit Memo Installments <span>(Read-only)</span></a>
+          <ul class="nav nav-stacked">
+              <li><a href="#creditmemoinstallmentjsonformat">JSON Format</a>
+              </li>
+              <li><a href="#creditmemoinstallmentjsonexample">JSON Example</a>
+              </li>
+              <li><a href="#creditmemoinstallmentavailablemethods">Available Methods</a>
+              </li>
+          </ul>
+      </li>
+      <!-- credit memo payments -->
+      <li>
+          <a href="#creditmemopayment">Credit Memo Payments</a>
+          <ul class="nav nav-stacked">
+              <li><a href="#creditmemopaymentjsonformat">JSON Format</a>
+              </li>
+              <li><a href="#creditmemopaymentjsonexample">JSON Example</a>
+              </li>
+              <li><a href="#creditmemopaymentfilter">Available Filter Fields</a>
+              </li>
+              <li><a href="#creditmemopaymentavailablemethods">Available Methods</a>
+              </li>
+          </ul>
+      </li>
         <!-- vendor credit memos -->
         <li>
             <a href="#vendorcreditmemo">Vendor credit memos</a>
@@ -519,6 +545,8 @@ title: "- REST API V1.0 Resources"
     <div>{% include 1.0/api/payment.html %}</div>
     <div>{% include 1.0/api/bill-payment.html %}</div>
     <div>{% include 1.0/api/creditmemo.html %}</div>
+    <div>{% include 1.0/api/credit-memo-installment.html %}</div>
+    <div>{% include 1.0/api/credit-memo-payment.html %}</div>
     <div>{% include 1.0/api/vendor-credit-memo.html %}</div>
     <div>{% include 1.0/api/sales-receipt.html %}</div>
     <div>{% include 1.0/api/expense.html %}</div>

--- a/docs/1.0/api/index.html
+++ b/docs/1.0/api/index.html
@@ -329,6 +329,32 @@ title: "- REST API V1.0 Resources"
               </li>
           </ul>
       </li>
+        <!-- vendor credit memo installments -->
+        <li>
+            <a href="#vendorcreditmemoinstallment">Vendor Credit Memo Installments <span>(Read-only)</span></a>
+            <ul class="nav nav-stacked">
+                <li><a href="#vendorcreditmemoinstallmentjsonformat">JSON Format</a>
+                </li>
+                <li><a href="#vendorcreditmemoinstallmentjsonexample">JSON Example</a>
+                </li>
+                <li><a href="#vendorcreditmemoinstallmentavailablemethods">Available Methods</a>
+                </li>
+            </ul>
+        </li>
+        <!-- vendor credit memo payments -->
+        <li>
+            <a href="#vendorcreditmemopayment">Vendor Credit Memo Payments</a>
+            <ul class="nav nav-stacked">
+                <li><a href="#vendorcreditmemopaymentjsonformat">JSON Format</a>
+                </li>
+                <li><a href="#vendorcreditmemopaymentjsonexample">JSON Example</a>
+                </li>
+                <li><a href="#vendorcreditmemopaymentfilter">Available Filter Fields</a>
+                </li>
+                <li><a href="#vendorcreditmemopaymentavailablemethods">Available Methods</a>
+                </li>
+            </ul>
+        </li>
       <!-- transactions -->
       <li>
           <a href="#transaction">Accounting Transactions</a>
@@ -550,6 +576,8 @@ title: "- REST API V1.0 Resources"
     <div>{% include 1.0/api/vendor-credit-memo.html %}</div>
     <div>{% include 1.0/api/sales-receipt.html %}</div>
     <div>{% include 1.0/api/expense.html %}</div>
+    <div>{% include 1.0/api/vendor-credit-memo-installment.html %}</div>
+    <div>{% include 1.0/api/vendor-credit-memo-payment.html %}</div>
     <div>{% include 1.0/api/transaction.html %}</div>
     <div>{% include 1.0/api/journal.html %}</div>
     <div>{% include 1.0/api/account.html %}</div>


### PR DESCRIPTION
Based on the feature/credit-memo-pojo-installments branch of myerp:
- Add credit-memo-installment.html: read-only endpoint for /credit_memo_installments
- Add credit-memo-payment.html: CRUD endpoint for /credit_memo_payments
- Add JSON examples for credit_memo_installment and credit_memo_payment
- Update creditmemo.html to document the installments array field
- Update credit_memo.json example to include installments
- Register new resource URLs in _config.yml
- Update index.html navigation and content includes