### PR TITLE
Add API documentation for Sales Receipts, Expenses, and Bank Transfers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,6 +83,12 @@ resource:
     url: /project_tasks
   domains:
     url: /domains
+  sales_receipts:
+    url: /sales_receipts
+  expenses:
+    url: /expenses
+  bank_transfers:
+    url: /bank_transfers
 
 format:
   date: yyyy-MM-dd (e.g. 2013-06-26)
@@ -113,3 +119,4 @@ format:
     top_invoiced: 'array[<a href="/docs/1.0/api/#top_invoiced" alt=""/>Top invoiced</a>]'
     snippet: '<a href="/docs/1.0/api/#snippet" title="">Snippet</a>'
     vendor: '<a href="/docs/1.0/api/#vendor" title="">Vendor</a>'
+    category_line: 'array[<a href="/docs/1.0/api/#categoryline" title="">Category Line</a>]'

--- a/_includes/1.0/api/bank-transfer.html
+++ b/_includes/1.0/api/bank-transfer.html
@@ -1,0 +1,107 @@
+<div id="banktransfer" class="group">
+
+    <h2>Bank Transfers</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.bank_transfers.url}}{% endhighlight %}
+    <p>A Bank Transfer records a movement of money between two bank accounts.
+        <br />You can specify both the source (<i>from</i>) and destination (<i>to</i>) accounts, or only one of the two — for example, if you are only the receiving party and do not manage the sending account in OneUp, or vice versa.
+        <br />Multi-currency transfers are supported: if <i>from</i> and <i>to</i> use different currencies, exchange rates are computed automatically.</p>
+
+    <h3 id="banktransferjsonformat">JSON Format</h3>
+    <p>Bank Transfers are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Automatically assigned when creating a Bank Transfer.</td>
+            </tr>
+            <tr>
+                <td>user_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The number automatically assigned to this Bank Transfer (e.g. BTRF-007).</td>
+            </tr>
+            <tr>
+                <td>date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The date of the transfer.<br />Format: {{ site.format.date }}<br />Default: date of the day.</td>
+            </tr>
+            <tr>
+                <td>notes</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>A description of the transfer purpose. 255 characters max.</td>
+            </tr>
+            <tr>
+                <td>from</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The debit side of the transfer. See <i>Transfer Direction</i> table below. Can be omitted if you are only the receiving party.</td>
+            </tr>
+            <tr>
+                <td>to</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The credit side of the transfer. See <i>Transfer Direction</i> table below. Can be omitted if you are only the sending party.</td>
+            </tr>
+            <tr>
+                <td>budget_category</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The budget category associated with this transfer. Contains <i>id</i> and <i>name</i>.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="banktransferdirection">Transfer Direction (<code>from</code> / <code>to</code>)</h3>
+    <p>Both <i>from</i> and <i>to</i> share the same structure:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>bank_account</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The bank account on this side of the transfer. Contains <i>id</i> and <i>name</i>.<br /><i>from.bank_account</i> and <i>to.bank_account</i> must be different when both are provided.</td>
+            </tr>
+            <tr>
+                <td>amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>yes</td>
+                <td>no</td>
+                <td>The transfer amount on this side. Must be greater than 0.</td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The ISO code of the currency <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>. Derived from the bank account's currency.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="banktransferjsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/bank_transfer.json %}{% endhighlight %}
+
+    <h3 id="banktransferavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/full.html %}
+
+</div>

--- a/_includes/1.0/api/expense.html
+++ b/_includes/1.0/api/expense.html
@@ -1,0 +1,227 @@
+<div id="expense" class="group">
+
+    <h2>Expenses</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.expenses.url}}{% endhighlight %}
+    <p>An Expense represents a categorized outgoing payment made to a vendor, employee, or any other payee — without going through a vendor bill.
+        <br />It is made up of one or more <a href="/docs/1.0/api/#categoryline" title="">Category Lines</a> that split the total amount across accounting accounts and budget categories.
+        <br />Setting a <i>payment_date</i> (or a <i>bank_account</i>) marks the document as paid. Clearing them reverts it to unpaid.
+        <br />
+        <br />Expenses share the same structure as <a href="/docs/1.0/api/#salesreceipt" title="">Sales Receipts</a>, with the distinction that expense lines use deductible taxes instead of collected taxes.
+        <br />
+        <br />A <i>POST /v1/expenses/search</i> endpoint is also available for advanced filtering.</p>
+
+    <h3 id="expensejsonformat">JSON Format</h3>
+    <p>Expenses are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Automatically assigned when creating an Expense.</td>
+            </tr>
+            <tr>
+                <td>user_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The number automatically assigned to this Expense (e.g. EXP-008). 64 characters max.</td>
+            </tr>
+            <tr>
+                <td>status</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Payment status of the document. <code>paid</code> when a <i>payment_date</i> is set, <code>not_paid</code> otherwise.</td>
+            </tr>
+            <tr>
+                <td>type</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>Whether the document has a single line or multiple lines. Values: <code>simple</code>, <code>multi-line</code>.</td>
+            </tr>
+            <tr>
+                <td>payee_type</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>Type of the payee. Values: <code>CUSTOMER</code>, <code>VENDOR</code>, <code>EMPLOYEE</code>, <code>BANK_ACCOUNT</code>, <code>NO_PAYEE</code>.</td>
+            </tr>
+            <tr>
+                <td>payee</td>
+                <td>{{ site.format.type.snippet }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The payee of this Expense. Must belong to the type specified by <i>payee_type</i>.</td>
+            </tr>
+            <tr>
+                <td>date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The date of the Expense.<br />Format: {{ site.format.date }}<br />Default: date of the day.</td>
+            </tr>
+            <tr>
+                <td>due_date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The due date for payment (for unpaid documents).<br />Format: {{ site.format.date }}</td>
+            </tr>
+            <tr>
+                <td>payment_date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The date the payment was debited from the bank account. Setting this field marks the document as <code>paid</code>.<br />Format: {{ site.format.date }}</td>
+            </tr>
+            <tr>
+                <td>payment_method</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The payment method used (e.g. <code>CHECK</code>, <code>WIRE_TRANSFER</code>, <code>CREDIT_CARD</code>).</td>
+            </tr>
+            <tr>
+                <td>bank_account</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The bank account the amount was debited from. Contains <i>id</i> and <i>name</i>.</td>
+            </tr>
+            <tr>
+                <td>transaction_id</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>A free reference label (e.g. a bank statement reference). 255 characters max.</td>
+            </tr>
+            <tr>
+                <td>notes</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>Free notes attached to this Expense. 255 characters max.</td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The ISO code of the currency <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>.<br />Default: your company's currency.</td>
+            </tr>
+            <tr>
+                <td>total_amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Total amount including taxes. Computed from the sum of all category lines.</td>
+            </tr>
+            <tr>
+                <td>assigned_to</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The employee assigned to this document. Contains <i>id</i>, <i>first_name</i>, <i>last_name</i>.<br />Default: the authenticated user.</td>
+            </tr>
+            <tr>
+                <td>project</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The project this Expense is linked to, if any. Contains <i>id</i> and <i>name</i>.</td>
+            </tr>
+            <tr>
+                <td>locked</td>
+                <td>{{ site.format.type.boolean }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Indicates that the document can no longer be edited nor deleted (e.g. due to a locked accounting period or VAT reconciliation).</td>
+            </tr>
+            <tr>
+                <td>bank_reconciled</td>
+                <td>{{ site.format.type.boolean }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Indicates whether this Expense has been matched against a bank entry.</td>
+            </tr>
+            <tr>
+                <td>lines</td>
+                <td>{{ site.format.type.category_line }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The category lines of this Expense. Adding, updating or removing a line updates <i>total_amount</i> accordingly.</td>
+            </tr>
+            <tr>
+                <td>metadata</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Extended status information. Contains <i>document_status</i> and <i>payment_status</i> keys.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="expensejsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/expense.json %}{% endhighlight %}
+
+    <h3 id="expensefilter">Available Filter Fields</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        {% include table-header-filter.html %}
+        </thead>
+        <tbody>
+        <tr>
+            <td>date</td>
+            <td>Filter by document date. Supports range queries.</td>
+        </tr>
+        <tr>
+            <td>payee_type</td>
+            <td>Filter by payee type (CUSTOMER, VENDOR, EMPLOYEE, BANK_ACCOUNT, NO_PAYEE).</td>
+        </tr>
+        <tr>
+            <td>status</td>
+            <td>Filter by payment status: <code>paid</code> or <code>not_paid</code>.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 id="expensesorting">Available Sorting Options</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        {% include table-header-sorting.html %}
+        </thead>
+        <tbody>
+        <tr>
+            <td>id</td>
+            <td>Sorts by id field.</td>
+        </tr>
+        <tr>
+            <td>date</td>
+            <td>Sorts by date field.</td>
+        </tr>
+        <tr>
+            <td>created_at</td>
+            <td>Sorts by the creation date field.</td>
+        </tr>
+        <tr>
+            <td>updated_at</td>
+            <td>Sorts by the update date field.</td>
+        </tr>
+        <tr>
+            <td>user_code</td>
+            <td>Sorts by the user_code field.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 id="expenseavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/full.html %}
+
+</div>

--- a/_includes/1.0/api/json/bank_transfer.json
+++ b/_includes/1.0/api/json/bank_transfer.json
@@ -1,0 +1,17 @@
+{
+  "id": 7,
+  "user_code": "BTRF-007",
+  "date": "2024-03-15",
+  "notes": "Monthly reserve top-up",
+  "from": {
+    "bank_account": { "id": 1, "name": "Main Checking" },
+    "amount": 5000.00,
+    "currency_iso_code": "EUR"
+  },
+  "to": {
+    "bank_account": { "id": 2, "name": "Savings Reserve" },
+    "amount": 5000.00,
+    "currency_iso_code": "EUR"
+  },
+  "budget_category": { "id": 3, "name": "Internal transfer" }
+}

--- a/_includes/1.0/api/json/expense.json
+++ b/_includes/1.0/api/json/expense.json
@@ -1,0 +1,37 @@
+{
+  "id": 8,
+  "user_code": "EXP-008",
+  "status": "paid",
+  "type": "multi-line",
+  "payee_type": "VENDOR",
+  "payee": { "id": 3, "name": "Office Supplies Co.", "user_code": "FOU-003" },
+  "date": "2024-03-10",
+  "payment_date": "2024-03-10",
+  "payment_method": "CREDIT_CARD",
+  "bank_account": { "id": 2, "name": "Corporate Card" },
+  "transaction_id": "TXN-20240310-004",
+  "notes": null,
+  "currency_iso_code": "EUR",
+  "total_amount": 59.99,
+  "assigned_to": { "id": 1, "first_name": "Jane", "last_name": "Doe" },
+  "project": null,
+  "locked": false,
+  "bank_reconciled": false,
+  "lines": [
+    {
+      "id": 1,
+      "total_amount": 59.99,
+      "sub_total_amount": 49.99,
+      "tax_amount": 10.00,
+      "price_mode": "withTaxes",
+      "tax": { "id": 2, "name": "TVA 20%", "rate": 20.0 },
+      "accounting_account": { "id": 7, "name": "Office supplies", "number": "606300" },
+      "budget_category": { "id": 5, "name": "Office supplies" },
+      "notes": "Printer paper and pens"
+    }
+  ],
+  "metadata": {
+    "document_status": "EXPENSE_OPEN",
+    "payment_status": "EXPENSE_PAID"
+  }
+}

--- a/_includes/1.0/api/json/sales_receipt.json
+++ b/_includes/1.0/api/json/sales_receipt.json
@@ -1,0 +1,37 @@
+{
+  "id": 12,
+  "user_code": "REC-012",
+  "status": "deposited",
+  "type": "multi-line",
+  "payee_type": "CUSTOMER",
+  "payee": { "id": 5, "name": "ACME Corp", "user_code": "CLI-005" },
+  "date": "2024-03-15",
+  "payment_date": "2024-03-20",
+  "payment_method": "CHECK",
+  "bank_account": { "id": 1, "name": "Main Checking" },
+  "transaction_id": null,
+  "notes": null,
+  "currency_iso_code": "EUR",
+  "total_amount": 120.00,
+  "assigned_to": { "id": 1, "first_name": "Jane", "last_name": "Doe" },
+  "project": null,
+  "locked": false,
+  "bank_reconciled": false,
+  "lines": [
+    {
+      "id": 1,
+      "total_amount": 120.00,
+      "sub_total_amount": 100.00,
+      "tax_amount": 20.00,
+      "price_mode": "withTaxes",
+      "tax": { "id": 1, "name": "TVA 20%", "rate": 20.0 },
+      "accounting_account": { "id": 2, "name": "Sales revenue", "number": "706000" },
+      "budget_category": { "id": 1, "name": "Services" },
+      "notes": "Q1 consulting services"
+    }
+  ],
+  "metadata": {
+    "document_status": "SALES_RECEIPT_OPEN",
+    "payment_status": "SALES_RECEIPT_PAID"
+  }
+}

--- a/_includes/1.0/api/nestedelements.html
+++ b/_includes/1.0/api/nestedelements.html
@@ -258,6 +258,83 @@
         {% highlight bash %}{% include 1.0/api/json/orderline.json %}{% endhighlight %}
     </div>
 
+    <div id="categoryline" class="group">
+        <h2>Category Line</h2>
+        <p>Category lines are embedded within <a href="/docs/1.0/api/#salesreceipt" title="">Sales Receipts</a> and <a href="/docs/1.0/api/#expense" title="">Expenses</a>. They split the total amount of a document across accounting accounts and budget categories, each optionally carrying a tax.<br />While adding, removing or updating a category line, the parent document's <i>total_amount</i> is updated accordingly.</p>
+        <h3>JSON Format</h3>
+        <p>Category lines are represented as JSON objects which have the following keys:</p>
+        <table class="table table-bordered table-striped">
+            <thead>
+                {% include table-header.html %}
+            </thead>
+            <tbody>
+                <tr>
+                    <td>id</td>
+                    <td>{{ site.format.type.integer }}</td>
+                    <td>no</td>
+                    <td>yes</td>
+                    <td>Automatically assigned.</td>
+                </tr>
+                <tr>
+                    <td>total_amount</td>
+                    <td>{{ site.format.type.double }}</td>
+                    <td>yes</td>
+                    <td>no</td>
+                    <td>Line total including tax. The sum of all lines must be strictly positive.</td>
+                </tr>
+                <tr>
+                    <td>sub_total_amount</td>
+                    <td>{{ site.format.type.double }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>Line total excluding tax.</td>
+                </tr>
+                <tr>
+                    <td>tax_amount</td>
+                    <td>{{ site.format.type.double }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>Tax amount for this line.</td>
+                </tr>
+                <tr>
+                    <td>price_mode</td>
+                    <td>{{ site.format.type.string }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>Determines which amount field is authoritative when computing the tax breakdown. Values: <code>withTaxes</code> (uses <i>total_amount</i>), <code>withoutTaxes</code> (uses <i>sub_total_amount</i>).</td>
+                </tr>
+                <tr>
+                    <td>tax</td>
+                    <td>{{ site.format.type.object }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>The <a href="/docs/1.0/api/#tax" title="">Tax</a> to apply on this line. Contains <i>id</i>, <i>name</i>, and <i>rate</i>.</td>
+                </tr>
+                <tr>
+                    <td>accounting_account</td>
+                    <td>{{ site.format.type.object }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>The <a href="/docs/1.0/api/#account" title="">Accounting Account</a> to assign this line to. Contains <i>id</i>, <i>name</i>, and <i>number</i>.</td>
+                </tr>
+                <tr>
+                    <td>budget_category</td>
+                    <td>{{ site.format.type.object }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>The budget category to assign this line to. Contains <i>id</i> and <i>name</i>.</td>
+                </tr>
+                <tr>
+                    <td>notes</td>
+                    <td>{{ site.format.type.string }}</td>
+                    <td>no</td>
+                    <td>no</td>
+                    <td>A description for this line. 255 characters max.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
     <div id="snippet" class="group">
         <h2>Snippet</h2>
     	<p>A Snippet is a generic type that encapsulates an object and aggregates common information.</p>

--- a/_includes/1.0/api/sales-receipt.html
+++ b/_includes/1.0/api/sales-receipt.html
@@ -1,0 +1,225 @@
+<div id="salesreceipt" class="group">
+
+    <h2>Sales Receipts</h2>
+    {% highlight bash %}Endpoint: {{ site.api.base_url }}{{ site.api.v1}}{{ site.resource.sales_receipts.url}}{% endhighlight %}
+    <p>A Sales Receipt represents a categorized income collected directly from a customer, vendor, employee, or any other payee — without going through an invoice.
+        <br />It is made up of one or more <a href="/docs/1.0/api/#categoryline" title="">Category Lines</a> that split the total amount across accounting accounts and budget categories.
+        <br />Setting a <i>payment_date</i> (or a <i>bank_account</i>) marks the document as deposited. Clearing them reverts it to unpaid.
+        <br />
+        <br />A <i>POST /v1/sales_receipts/search</i> endpoint is also available for advanced filtering.</p>
+
+    <h3 id="salesreceiptjsonformat">JSON Format</h3>
+    <p>Sales Receipts are represented as JSON objects which have the following keys:</p>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+            {% include table-header.html %}
+        </thead>
+        <tbody>
+            <tr>
+                <td>id</td>
+                <td>{{ site.format.type.integer }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Automatically assigned when creating a Sales Receipt.</td>
+            </tr>
+            <tr>
+                <td>user_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>The number automatically assigned to this Sales Receipt (e.g. REC-012). 64 characters max.</td>
+            </tr>
+            <tr>
+                <td>status</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Payment status of the document. <code>deposited</code> when a <i>payment_date</i> is set, <code>not_deposited</code> otherwise.</td>
+            </tr>
+            <tr>
+                <td>type</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>Whether the document has a single line or multiple lines. Values: <code>simple</code>, <code>multi-line</code>.</td>
+            </tr>
+            <tr>
+                <td>payee_type</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>Type of the payee. Values: <code>CUSTOMER</code>, <code>VENDOR</code>, <code>EMPLOYEE</code>, <code>BANK_ACCOUNT</code>, <code>NO_PAYEE</code>.</td>
+            </tr>
+            <tr>
+                <td>payee</td>
+                <td>{{ site.format.type.snippet }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The payee of this Sales Receipt. Must belong to the type specified by <i>payee_type</i>.</td>
+            </tr>
+            <tr>
+                <td>date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The date of the Sales Receipt.<br />Format: {{ site.format.date }}<br />Default: date of the day.</td>
+            </tr>
+            <tr>
+                <td>due_date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The due date for payment (for unpaid documents).<br />Format: {{ site.format.date }}</td>
+            </tr>
+            <tr>
+                <td>payment_date</td>
+                <td>{{ site.format.type.date }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The date the payment was deposited to the bank account. Setting this field marks the document as <code>deposited</code>.<br />Format: {{ site.format.date }}</td>
+            </tr>
+            <tr>
+                <td>payment_method</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The payment method used (e.g. <code>CHECK</code>, <code>WIRE_TRANSFER</code>, <code>CREDIT_CARD</code>).</td>
+            </tr>
+            <tr>
+                <td>bank_account</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The bank account the amount was deposited into. Contains <i>id</i> and <i>name</i>.</td>
+            </tr>
+            <tr>
+                <td>transaction_id</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>A free reference label (e.g. a bank statement reference). 255 characters max.</td>
+            </tr>
+            <tr>
+                <td>notes</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>Free notes attached to this Sales Receipt. 255 characters max.</td>
+            </tr>
+            <tr>
+                <td>currency_iso_code</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The ISO code of the currency <a href="http://www.iso.org/iso/catalogue_detail?csnumber=46121" target="_blank" title="ISO 4217">(ISO 4217)</a>.<br />Default: your company's currency.</td>
+            </tr>
+            <tr>
+                <td>total_amount</td>
+                <td>{{ site.format.type.double }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Total amount including taxes. Computed from the sum of all category lines.</td>
+            </tr>
+            <tr>
+                <td>assigned_to</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The employee assigned to this document. Contains <i>id</i>, <i>first_name</i>, <i>last_name</i>.<br />Default: the authenticated user.</td>
+            </tr>
+            <tr>
+                <td>project</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The project this Sales Receipt is linked to, if any. Contains <i>id</i> and <i>name</i>.</td>
+            </tr>
+            <tr>
+                <td>locked</td>
+                <td>{{ site.format.type.boolean }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Indicates that the document can no longer be edited nor deleted (e.g. due to a locked accounting period or VAT reconciliation).</td>
+            </tr>
+            <tr>
+                <td>bank_reconciled</td>
+                <td>{{ site.format.type.boolean }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Indicates whether this Sales Receipt has been matched against a bank entry.</td>
+            </tr>
+            <tr>
+                <td>lines</td>
+                <td>{{ site.format.type.category_line }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The category lines of this Sales Receipt. Adding, updating or removing a line updates <i>total_amount</i> accordingly.</td>
+            </tr>
+            <tr>
+                <td>metadata</td>
+                <td>{{ site.format.type.object }}</td>
+                <td>no</td>
+                <td>yes</td>
+                <td>Extended status information. Contains <i>document_status</i> and <i>payment_status</i> keys.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3 id="salesreceiptjsonexample">JSON Example</h3>
+    {% highlight bash %}{% include 1.0/api/json/sales_receipt.json %}{% endhighlight %}
+
+    <h3 id="salesreceiptfilter">Available Filter Fields</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        {% include table-header-filter.html %}
+        </thead>
+        <tbody>
+        <tr>
+            <td>date</td>
+            <td>Filter by document date. Supports range queries.</td>
+        </tr>
+        <tr>
+            <td>payee_type</td>
+            <td>Filter by payee type (CUSTOMER, VENDOR, EMPLOYEE, BANK_ACCOUNT, NO_PAYEE).</td>
+        </tr>
+        <tr>
+            <td>status</td>
+            <td>Filter by payment status: <code>deposited</code> or <code>not_deposited</code>.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 id="salesreceiptsorting">Available Sorting Options</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        {% include table-header-sorting.html %}
+        </thead>
+        <tbody>
+        <tr>
+            <td>id</td>
+            <td>Sorts by id field.</td>
+        </tr>
+        <tr>
+            <td>date</td>
+            <td>Sorts by date field.</td>
+        </tr>
+        <tr>
+            <td>created_at</td>
+            <td>Sorts by the creation date field.</td>
+        </tr>
+        <tr>
+            <td>updated_at</td>
+            <td>Sorts by the update date field.</td>
+        </tr>
+        <tr>
+            <td>user_code</td>
+            <td>Sorts by the user_code field.</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3 id="salesreceiptavailablemethods">Available Methods</h3>
+    {% include 1.0/api/methods/full.html %}
+
+</div>

--- a/docs/1.0/api/index.html
+++ b/docs/1.0/api/index.html
@@ -271,6 +271,38 @@ title: "- REST API V1.0 Resources"
                 </li>
             </ul>
         </li>
+      <!-- sales receipts -->
+      <li>
+          <a href="#salesreceipt">Sales Receipts</a>
+          <ul class="nav nav-stacked">
+              <li><a href="#salesreceiptjsonformat">JSON Format</a>
+              </li>
+              <li><a href="#salesreceiptjsonexample">JSON Example</a>
+              </li>
+              <li><a href="#salesreceiptfilter">Available Filter Fields</a>
+              </li>
+              <li><a href="#salesreceiptsorting">Available Sorting Options</a>
+              </li>
+              <li><a href="#salesreceiptavailablemethods">Available Methods</a>
+              </li>
+          </ul>
+      </li>
+      <!-- expenses -->
+      <li>
+          <a href="#expense">Expenses</a>
+          <ul class="nav nav-stacked">
+              <li><a href="#expensejsonformat">JSON Format</a>
+              </li>
+              <li><a href="#expensejsonexample">JSON Example</a>
+              </li>
+              <li><a href="#expensefilter">Available Filter Fields</a>
+              </li>
+              <li><a href="#expensesorting">Available Sorting Options</a>
+              </li>
+              <li><a href="#expenseavailablemethods">Available Methods</a>
+              </li>
+          </ul>
+      </li>
       <!-- transactions -->
       <li>
           <a href="#transaction">Accounting Transactions</a>
@@ -326,6 +358,20 @@ title: "- REST API V1.0 Resources"
               <li><a href="#bankentrysorting">Available Sorting Options</a>
               </li>
               <li><a href="#bankentryavailablemethods">Available Methods</a>
+              </li>
+          </ul>
+      </li>
+      <!-- bank transfers -->
+      <li>
+          <a href="#banktransfer">Bank Transfers</a>
+          <ul class="nav nav-stacked">
+              <li><a href="#banktransferjsonformat">JSON Format</a>
+              </li>
+              <li><a href="#banktransferdirection">Transfer Direction</a>
+              </li>
+              <li><a href="#banktransferjsonexample">JSON Example</a>
+              </li>
+              <li><a href="#banktransferavailablemethods">Available Methods</a>
               </li>
           </ul>
       </li>
@@ -399,6 +445,8 @@ title: "- REST API V1.0 Resources"
               </li>
               <li><a href="#orderline">Order line</a>
               </li>
+              <li><a href="#categoryline">Category Line</a>
+              </li>
               <li><a href="#snippet">Snippet</a>
               </li>
           </ul>
@@ -438,11 +486,14 @@ title: "- REST API V1.0 Resources"
     <div>{% include 1.0/api/bill-payment.html %}</div>
     <div>{% include 1.0/api/creditmemo.html %}</div>
     <div>{% include 1.0/api/vendor-credit-memo.html %}</div>
+    <div>{% include 1.0/api/sales-receipt.html %}</div>
+    <div>{% include 1.0/api/expense.html %}</div>
     <div>{% include 1.0/api/transaction.html %}</div>
     <div>{% include 1.0/api/journal.html %}</div>
     <div>{% include 1.0/api/account.html %}</div>
     <div>{% include 1.0/api/bankaccount.html %}</div>
     <div>{% include 1.0/api/bankentry.html %}</div>
+    <div>{% include 1.0/api/bank-transfer.html %}</div>
     <div>{% include 1.0/api/paymentterm.html %}</div>
     <div>{% include 1.0/api/tax.html %}</div>
     <div>{% include 1.0/api/currency.html %}</div>


### PR DESCRIPTION
Closes #45

## Summary

- **Sales Receipts** (`/v1/sales_receipts`): full field table, JSON example, filter/sort options, search endpoint note
- **Expenses** (`/v1/expenses`): same structure, expense-specific status values (`paid`/`not_paid`), deductible taxes
- **Bank Transfers** (`/v1/bank_transfers`): main table + `from`/`to` direction sub-table (multi-currency supported)
- **Category Line** (new nested element): shared line structure embedded in both Sales Receipts and Expenses
- `_config.yml`: 3 new resource URL definitions + `category_line` format type
- `index.html`: sidebar entries and content includes for all new sections

## Test plan

- [ ] Build the Jekyll site locally and browse to each new section
- [ ] Verify sidebar anchors navigate correctly for all new entries
- [ ] Confirm Category Line is reachable from both Sales Receipt and Expense `lines` field links
- [ ] Confirm Bank Transfer direction sub-table anchor resolves correctly
- [ ] Check JSON examples render in highlight blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)