### PR TITLE
Add vendor ref number docs

### DIFF
--- a/_includes/1.0/api/json/vendor_bill.json
+++ b/_includes/1.0/api/json/vendor_bill.json
@@ -11,6 +11,7 @@
   },
   "id": 10002,
   "user_code": "VINV-001",
+  "ref_number": "REF-1234",
   "date": "2026-01-12",
   "currency_iso_code": "GBP",
   "reduce_rate": 10.0,

--- a/_includes/1.0/api/json/vendor_credit_memo.json
+++ b/_includes/1.0/api/json/vendor_credit_memo.json
@@ -6,6 +6,7 @@
   "unpaid": 0.0,
   "id": 10000,
   "user_code": "SCN-001",
+  "ref_number": "REF-5678",
   "date": "2020-10-06",
   "currency_iso_code": "GBP",
   "employee_id": 10028,

--- a/_includes/1.0/api/vendor-bill.html
+++ b/_includes/1.0/api/vendor-bill.html
@@ -82,6 +82,13 @@
                 <td>The number assigned to this bill (i.e. VINV-002). If you don't specify a bill number, it will be automatically generated. 64 characters max.</td>
             </tr>
             <tr>
+                <td>ref_number</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The vendor's own reference number for this bill (e.g. their invoice number). 255 characters max.</td>
+            </tr>
+            <tr>
                 <td>date</td>
                 <td>{{ site.format.type.date }}</td>
                 <td>no</td>

--- a/_includes/1.0/api/vendor-credit-memo.html
+++ b/_includes/1.0/api/vendor-credit-memo.html
@@ -131,7 +131,7 @@
     </table>
 
     <h3 id="vendorcreditmemojsonexample">JSON Example</h3>
-    {% highlight bash %}{% include 1.0/api/json/vendor_bill.json %}{% endhighlight %}
+    {% highlight bash %}{% include 1.0/api/json/vendor_credit_memo.json %}{% endhighlight %}
 
     <h3 id="vendorcreditmemosorting">Available Sorting Options</h3>
     <table class="table table-bordered table-striped">

--- a/_includes/1.0/api/vendor-credit-memo.html
+++ b/_includes/1.0/api/vendor-credit-memo.html
@@ -62,6 +62,13 @@
                 <td>The number assigned to this bill (i.e. SCN-001). If you don't specify a a credit memo number, it will be automatically generated. 64 characters max.</td>
             </tr>
             <tr>
+                <td>ref_number</td>
+                <td>{{ site.format.type.string }}</td>
+                <td>no</td>
+                <td>no</td>
+                <td>The vendor's own reference number for this credit memo. 64 characters max.</td>
+            </tr>
+            <tr>
                 <td>date</td>
                 <td>{{ site.format.type.date }}</td>
                 <td>no</td>


### PR DESCRIPTION
This PR updates the doc concerning the addition of field ref_number on both VendorBillPOJO and VendorCreditMemoPOJO