### PR TITLE
update vendor bill api doc with ref_number length (database coherent)

### DIFF
--- a/_includes/1.0/api/vendor-bill.html
+++ b/_includes/1.0/api/vendor-bill.html
@@ -86,7 +86,7 @@
                 <td>{{ site.format.type.string }}</td>
                 <td>no</td>
                 <td>no</td>
-                <td>The vendor's own reference number for this bill (e.g. their invoice number). 100 characters max.
+                <td>The vendor's own reference number for this bill (e.g. their invoice number). 255 characters max.
                   <br>this field can be cleared with a blank or empty string only, not a null value
                 </td>
             </tr>


### PR DESCRIPTION
this PR updates the vendor bill api doc with ref_number length to be coherent with the database